### PR TITLE
Fix "Implicit conversin from float" deprecation in php8.3

### DIFF
--- a/src/WordList/StaticArray.php
+++ b/src/WordList/StaticArray.php
@@ -23,7 +23,7 @@ class StaticArray implements WordListInterface
     public function get($random)
     {
         $length = count(static::$words);
-        $position = $random * ($length - 1);
+        $position = (int)($random * ($length - 1));
 
         return static::$words[$position];
     }


### PR DESCRIPTION
Trying to get array element by float index throws "Implicit conversin from float" dreprecation in php8.3. This fix added direct type cast in order to avoid errors in the future versions.